### PR TITLE
Update zero_deed.html

### DIFF
--- a/cc/engine/templates/licenses/zero_deed.html
+++ b/cc/engine/templates/licenses/zero_deed.html
@@ -192,7 +192,7 @@
 
 {% block use_this_license %}
   {% trans %}
-        <a href="http://wiki.creativecommons.org/FAQ">Learn more</a> about CC licensing, or <a id="get_this" href="{{ get_this }}">use the license</a> for your own material.
+        <a href="http://wiki.creativecommons.org/FAQ">Learn more</a> about CC licensing, or <a id="get_this" href="https://creativecommons.org/choose/zero/">use the license</a> for your own material.
   {% endtrans %}
 {% endblock use_this_license %}
 


### PR DESCRIPTION
Should fix https://github.com/creativecommons/creativecommons.org/issues/864 as per suggestion of @robmyers 

Rationale. CC0 is not a license that is included in the license chooser. the license chooser API (that is being revamped as we speak I believe) does not know how to handle a license that does not exist in the chooser.

Fix is not ready for multilingual CC0 Deed pages. But better than having an error appear.