### PR TITLE
chooser image paths changed to its new location in new-creativecommons.org repo

### DIFF
--- a/cc/engine/templates/chooser_pages/interactive_chooser.html
+++ b/cc/engine/templates/chooser_pages/interactive_chooser.html
@@ -63,8 +63,8 @@ var CHOOSER = {
 
     // Constants
     "CONST" : {
-        "img_path" : "/wp-content/themes/creativecommons.org/images/",
-        "fc_approved" : "/wp-content/themes/creativecommons.org/images/fc_approved_tiny.png",
+        "img_path" : "/images/chooser/",
+        "fc_approved" : "/images/chooser/fc_approved_tiny.png",
         "links" : {
             "fc_by_sa" : "/freeworks",
             "fc_by" : "/freeworks"
@@ -511,7 +511,7 @@ input[type=radio] {
     //position: absolute; /* prevents help button from influence box packing */
     //display: none;
     //margin-top: 5px;
-background-image: url("/wp-content/themes/creativecommons.org/images/hint_button.png");
+background-image: url("/images/chooser/hint_button.png");
 width: 25px;
 height: 25px;
 display: block;
@@ -523,7 +523,7 @@ margin-left: 25px;
 }
 
 .help_button:ho2ver {
-    background-image: url("/wp-content/themes/creativecommons.org/images/hint_button_ho2ver.png");
+    background-image: url("/images/chooser/hint_button_hover.png");
     cursor: pointer;
 }
 
@@ -847,11 +847,11 @@ margin-bottom: 1em;
     width: 76px;
     height: 76px;
     cursor: pointer;
-    background-image: url('/wp-content/themes/creativecommons.org/images/fc_dubious.png');
+    background-image: url('/images/chooser/fc_dubious.png');
 }
 
 .require_js #fc_dubious_box .fc_logo_link:ho2ver {
-    background-image: url('/wp-content/themes/creativecommons.org/images/fc_dubious_ho2ver.png');
+    background-image: url('/images/chooser/fc_dubious_hover.png');
 }
 
 #fc_approved_box .fc_logo_link {
@@ -859,7 +859,7 @@ margin-bottom: 1em;
     width: 76px;
     height: 76px;
     cursor: pointer;
-    background-image: url('/wp-content/themes/creativecommons.org/images/fc_approved_tiny.png');
+    background-image: url('/images/chooser/fc_approved_tiny.png');
 }
 
 .whatis {
@@ -906,47 +906,47 @@ margin-bottom: 1em;
 }
 
 #cc_icon {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_cc.png');
+    background-image: url('/images/chooser/chooser_cc.png');
 }
 #by_icon {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_by.png');
+    background-image: url('/images/chooser/chooser_by.png');
 }
 #sa_icon {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_sa.png');
+    background-image: url('/images/chooser/chooser_sa.png');
 }
 #nd_icon {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_nd.png');
+    background-image: url('/images/chooser/chooser_nd.png');
 }
 #nc_icon {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_nc.png');
+    background-image: url('/images/chooser/chooser_nc.png');
 }
 .euro #nc_icon {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_nc_eu.png')!important;
+    background-image: url('/images/chooser/chooser_nc_eu.png')!important;
 }
 .yen #nc_icon {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_nc_jp.png')!important;
+    background-image: url('/images/chooser/chooser_nc_jp.png')!important;
 }
 
 #cc_icon:ho2ver {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_cc_ho2ver.png');
+    background-image: url('/images/chooser/chooser_cc_ho2ver.png');
 }
 #by_icon:ho2ver {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_by_ho2ver.png');
+    background-image: url('/images/chooser/chooser_by_ho2ver.png');
 }
 #sa_icon:ho2ver {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_sa_ho2ver.png');
+    background-image: url('/images/chooser/chooser_sa_ho2ver.png');
 }
 #nd_icon:ho2ver {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_nd_ho2ver.png');
+    background-image: url('/images/chooser/chooser_nd_ho2ver.png');
 }
 #nc_icon:ho2ver {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_nc_ho2ver.png');
+    background-image: url('/images/chooser/chooser_nc_ho2ver.png');
 }
 .euro #nc_icon:ho2ver {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_nc_eu_ho2ver.png')!important;
+    background-image: url('/images/chooser/chooser_nc_eu_ho2ver.png')!important;
 }
 .yen #nc_icon:ho2ver {
-    background-image: url('/wp-content/themes/creativecommons.org/images/chooser_nc_jp_ho2ver.png')!important;
+    background-image: url('/images/chooser/chooser_nc_jp_ho2ver.png')!important;
 }
 
 
@@ -1956,20 +1956,20 @@ work in the manner specified by the author or licensor.{% endtrans %}</div>
 
 <!-- this group of images shouldn't be visible, but exists to cause the browser to cache them -->
 <!-- <div style="display: none"> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/fc_dubious.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/fc_dubious_ho2ver.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_cc.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_by.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_nd.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_nc.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_nc_eu.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_nc_jp.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_cc_ho2ver.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_by_ho2ver.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_nd_ho2ver.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_nc_ho2ver.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_nc_eu_ho2ver.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/chooser_nc_jp_ho2ver.png" /> -->
-<!--   <img src="/wp-content/themes/creativecommons.org/images/hint_button_ho2ver.png" /> -->
+<!--   <img src="/images/chooser/fc_dubious.png" /> -->
+<!--   <img src="/images/chooser/fc_dubious_ho2ver.png" /> -->
+<!--   <img src="/images/chooser/chooser_cc.png" /> -->
+<!--   <img src="/images/chooser/chooser_by.png" /> -->
+<!--   <img src="/images/chooser/chooser_nd.png" /> -->
+<!--   <img src="/images/chooser/chooser_nc.png" /> -->
+<!--   <img src="/images/chooser/chooser_nc_eu.png" /> -->
+<!--   <img src="/images/chooser/chooser_nc_jp.png" /> -->
+<!--   <img src="/images/chooser/chooser_cc_ho2ver.png" /> -->
+<!--   <img src="/images/chooser/chooser_by_ho2ver.png" /> -->
+<!--   <img src="/images/chooser/chooser_nd_ho2ver.png" /> -->
+<!--   <img src="/images/chooser/chooser_nc_ho2ver.png" /> -->
+<!--   <img src="/images/chooser/chooser_nc_eu_ho2ver.png" /> -->
+<!--   <img src="/images/chooser/chooser_nc_jp_ho2ver.png" /> -->
+<!--   <img src="/images/chooser/hint_button_ho2ver.png" /> -->
 <!-- </div> -->
 {% endblock %}


### PR DESCRIPTION
Fixes creativecommons/creativecommons.org#755

**Description**
Chooser icons moved out from old cc.org theme. the paths from cc.engine template were replaced to its new location. Before applying this pull request make sure [this](https://github.com/creativecommons/creativecommons.org/pull/1013) is deployed


**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
