### PR TITLE
fix creativecommons/creativecommons.org#1027 - updated secondary menu

### DIFF
--- a/cc/engine/templates/includes/cc_site_header.html
+++ b/cc/engine/templates/includes/cc_site_header.html
@@ -16,7 +16,7 @@
             <li id="menu-item-48799" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48799"><a href="https://creativecommons.org/use-remix/">{% trans %}Use &#038; remix{% endtrans %}</a></li>
             <li id="menu-item-48800" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48800"><a href="https://creativecommons.org/about/">{% trans %}What We do{% endtrans %}</a></li>
             <li id="menu-item-48801" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48801"><a href="https://creativecommons.org/blog/">{% trans %}Blog{% endtrans %}</a></li>
-            <li id="menu-item-48802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48802"><a href="https://network.creativecommons.org/?ref=global-affiliate-network">{% trans %}Global Affiliate Network{% endtrans %}</a></li>
+            <li id="menu-item-48802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48802"><a href="https://network.creativecommons.org/?ref=global-affiliate-network">{% trans %}Global Network{% endtrans %}</a></li>
             <li id="menu-item-48803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48803"><a href="https://creativecommons.org/use-remix/search-the-commons/">{% trans %}Search the Commons{% endtrans %}</a></li>
           </ul></div>
         </nav><!-- .main-navigation -->

--- a/cc/engine/templates/includes/cc_site_header.html
+++ b/cc/engine/templates/includes/cc_site_header.html
@@ -14,9 +14,9 @@
           <div class="menu-mobile-menu-container"><ul id="menu-mobile-menu" class="mobile-menu">
             <li id="menu-item-48798" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48798"><a href="https://creativecommons.org/share-your-work/">{% trans %}Share your work{% endtrans %}</a></li>
             <li id="menu-item-48799" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48799"><a href="https://creativecommons.org/use-remix/">{% trans %}Use &#038; remix{% endtrans %}</a></li>
-            <li id="menu-item-48800" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48800"><a href="https://creativecommons.org/about/">{% trans %}What we do{% endtrans %}</a></li>
+            <li id="menu-item-48800" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48800"><a href="https://creativecommons.org/about/">{% trans %}What We do{% endtrans %}</a></li>
             <li id="menu-item-48801" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48801"><a href="https://creativecommons.org/blog/">{% trans %}Blog{% endtrans %}</a></li>
-            <li id="menu-item-48802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48802"><a href="https://creativecommons.org/about/global-affiliate-network/">{% trans %}Global Affiliate Network{% endtrans %}</a></li>
+            <li id="menu-item-48802" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48802"><a href="https://network.creativecommons.org/?ref=global-affiliate-network">{% trans %}Global Affiliate Network{% endtrans %}</a></li>
             <li id="menu-item-48803" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48803"><a href="https://creativecommons.org/use-remix/search-the-commons/">{% trans %}Search the Commons{% endtrans %}</a></li>
           </ul></div>
         </nav><!-- .main-navigation -->
@@ -25,14 +25,17 @@
           <div class="menu-primary-menu-container"><ul id="menu-primary-menu" class="primary-menu">
             <li id="menu-item-48791" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48791"><a href="https://creativecommons.org/share-your-work/">{% trans %}Share your work{% endtrans %}</a></li>
             <li id="menu-item-48792" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48792"><a href="https://creativecommons.org/use-remix/">{% trans %}Use &#038; remix{% endtrans %}</a></li>
-            <li id="menu-item-48570" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48570"><a href="https://creativecommons.org/about/">{% trans %}What we do{% endtrans %}</a></li>
+            <li id="menu-item-48570" class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-7466 menu-item-48570"><a href="https://creativecommons.org/about/">{% trans %}What We do{% endtrans %}</a></li>
             <li id="menu-item-48793" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48793"><a href="https://creativecommons.org/blog/">{% trans %}Blog{% endtrans %}</a></li>
           </ul></div>
         </nav>
 
         <nav id="secondary-navigation" class="secondary-navigation" role="navigation" aria-label="Secondary Menu">
-          <div class="menu-secondary-menu-container"><ul id="menu-secondary-menu" class="secondary-menu"><li id="menu-item-48804" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48804"><a href="https://creativecommons.org/about/global-affiliate-network/">{% trans %}Global Affiliate Network{% endtrans %}</a></li>
-            <li id="menu-item-48805" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48805"><a href="https://creativecommons.org/use-remix/search-the-commons/">{% trans %}Search the Commons{% endtrans %}</a></li>
+          <div class="menu-secondary-menu-container"><ul id="menu-secondary-menu" class="secondary-menu">
+            <li id="menu-item-55890" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-55890"><a href="https://search.creativecommons.org/">{% trans %}Search for CC images{% endtrans %}</a></li>
+            <li id="menu-item-48804" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48804"><a href="https://network.creativecommons.org/?ref=global-affiliate-network">{% trans %}Global Network{% endtrans %}</a></li>
+            <li id="menu-item-56460" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-56460"><a href="https://us.e-activist.com/page/6747/subscribe/1?ea.tracking.id=mailing-list-page">{% trans %}Newsletters{% endtrans %}</a></li>
+            <li id="menu-item-52800" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-52800"><a href="https://store.creativecommons.org/">{% trans %}Store{% endtrans %}</a></li>
             <li id="menu-item-48806" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-48806"><a href="https://creativecommons.org/about/contact/">{% trans %}Contact{% endtrans %}</a></li>
           </ul></div>
         </nav>


### PR DESCRIPTION
Fixes creativecommons/creativecommons.org#1027

**Description**
Update secondary menu on cc.engine (deeds and legal code) to be the same as cc.org


**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
