### PR TITLE
remove support for hiding banner on deeds for non-english translations

### DIFF
--- a/cc/engine/templates/macros_templates/deed.html
+++ b/cc/engine/templates/macros_templates/deed.html
@@ -50,8 +50,7 @@ xmlns:frbr="http://purl.org/vocab/frbr/core#" xml:lang="{{ target_lang }}">
 
 </head>
 
-{# Translators: Change hide-banner to an empty string to show the complete site header and footer #}
-<body typeof="cc:License" about="http://creativecommons.org/licenses/by/4.0/" class="license {{ get_ltr_rtl }} {% if target_lang != 'en' %}{% trans %}hide-banner{% endtrans %}{% endif %}">
+<body typeof="cc:License" about="http://creativecommons.org/licenses/by/4.0/" class="license {{ get_ltr_rtl }}">
   {% block page_top %}{% endblock %}
   <div id="page" class="site">
     <div class="site-inner">


### PR DESCRIPTION
**Description**
Remove support for hiding banner in non-english translations using english "hide-banner" phrase. Fixes https://github.com/creativecommons/creativecommons.org/issues/990

**Other information**
<!-- Add any other information below or delete the "Other Information" line entirely. -->

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [ ] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
