### PR TITLE
Add beta chooser banner to production chooser

### DIFF
--- a/cc/engine/templates/chooser_pages/interactive_chooser.html
+++ b/cc/engine/templates/chooser_pages/interactive_chooser.html
@@ -1324,7 +1324,11 @@ a.async=true;a.type="text/javascript";b.parentNode.insertBefore(a,b)}, 1);
 
 <span id="template_htmlrdfa" style="display:none;"></span>
 <span id="template_nondigital" style="display:none;">{%- trans license_name="LICENSE_NAME", license_url="LICENSE_URL" %}This work is licensed under the Creative Commons {{ license_name }} License. To view a copy of this license, visit {{ license_url }}.{% endtrans -%}</span>
-
+<!--Temporary banner for chooser beta-->
+<div class="beta-banner" style="border: 1px solid black;padding: 1.5rem;border-radius: .5rem;background-color: #EAFBC4;width: 100%;margin-bottom: 1.5rem;border: 2px solid #01A635;box-shadow: 1px 1px 4px rgba(0,0,0,.3);">
+  We are currently testing a new version of the License Chooser. Please consider using the <a href="https://chooser-beta.creativecommons.org/">Chooser beta</a>, and leave us feedback on how we can improve.
+</div>
+<!--End of temporary banner-->
 <div id="instructional_fluff">
   <span>{% trans %}New to Creative Commons?{% endtrans %}</span>
   <span>[ <a target="_blank" href="http://wiki.creativecommons.org/Before_Licensing">


### PR DESCRIPTION
## Fixes
Fixes #24 by @kgodey 

## Description
This adds a banner to notify users of the new [beta chooser](https://chooser-beta.creativecommons.org/)

**See https://stage.creativecommons.org/choose/** (per #30)

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
